### PR TITLE
Fix unresolved Math.sign function in older Chrome, Safari and more

### DIFF
--- a/public_html/assets/src/js/init.js
+++ b/public_html/assets/src/js/init.js
@@ -8,7 +8,15 @@ $().ready(function () {
 });
 
 String.prototype.contains = function (it) {
-    return this.indexOf(it) != -1;
+    return this.indexOf(it) !== -1;
+};
+
+Math.sign = Math.sign || function sign(x) {
+    x = +x; // convert to a number
+    if (x === 0 || isNaN(x)) {
+        return x;
+    }
+    return x > 0 ? 1 : -1;
 };
 
 


### PR DESCRIPTION
I was trying to use this last night, but it errored out saying Math.sign wasn't defined in my version of Chrome. I also noticed you had a bug report about it not working in Safari, and guessed that it was related. This just adds Math.sign if it's not defined. Fixes the issue for me in Chrome and Safari.
